### PR TITLE
fix: guard against empty choices and message=None across all model backends

### DIFF
--- a/common/models/azure_model.py
+++ b/common/models/azure_model.py
@@ -73,5 +73,6 @@ class AzureModel(BaseModel):
             params["response_format"] = response_format
         
         response = self.client.chat.completions.create(**params)
-        
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content

--- a/common/models/cerebras_model.py
+++ b/common/models/cerebras_model.py
@@ -56,5 +56,6 @@ class CerebrasModel(BaseModel):
             params["response_format"] = response_format
         
         response = self.client.chat.completions.create(**params)
-        
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content

--- a/common/models/groq_model.py
+++ b/common/models/groq_model.py
@@ -52,5 +52,6 @@ class GroqModel(BaseModel):
             params["response_format"] = response_format
 
         response = self.client.chat.completions.create(**params)
-
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content

--- a/common/models/openai_model.py
+++ b/common/models/openai_model.py
@@ -61,5 +61,6 @@ class OpenaiModel(BaseModel):
             params["response_format"] = response_format
         
         response = self.client.chat.completions.create(**params)
-        
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content


### PR DESCRIPTION
## What

Add explicit guards in all four model backend classes before accessing `response.choices[0].message.content`.

## Why

`client.chat.completions.create()` can return two empty-response shapes, neither currently handled:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures  
2. **`choices[0].message = None`** — e.g. Gemini 2.5 Flash via the OpenAI-compatible endpoint returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None`

Both crash with `IndexError` or `AttributeError`. All four model backends have identical unguarded access patterns.

## Files changed

| File | Fix |
|------|-----|
| `common/models/openai_model.py` | Guard before `choices[0].message.content` |
| `common/models/azure_model.py` | Guard before `choices[0].message.content` |
| `common/models/cerebras_model.py` | Guard before `choices[0].message.content` |
| `common/models/groq_model.py` | Guard before `choices[0].message.content` |

```python
# Before
return response.choices[0].message.content

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.7k violations in 786 repos.